### PR TITLE
Add automatic NuGet build and deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-dotnet@v1
     
     - name: Build with dotnet
-      run: dotnet build --configuration Release
+      run: dotnet build ./src/ --configuration Release
 
   deploy: 
     needs: build
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Pack NuGet package
-        run: dotnet pack --configuration Release
+        run: dotnet pack ./src/ --configuration Release
 
       - name: Push package to NuGet
         run: dotnet nuget push **/*.nupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Build and deploy
 
+env:
+  PKG_VERSION: 0.9.${{ github.run_number }}
+
 on:
   push:
     branches:
@@ -28,7 +31,7 @@ jobs:
       - name: Pack NuGet package
         run: dotnet pack ./src/ 
               --configuration Release 
-              -p:Version=0.9.${{ github.run_number }} 
+              -p:Version=${{ env.PKG_VERSION }} 
               -p:PackageId=Umbraco.Tools.Packages
 
       - name: Push package to NuGet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Pack NuGet package
-        run: dotnet pack ./src/ --configuration Release --version-suffix ${{ github.run_number }}
+        run: dotnet pack ./src/ --configuration Release -p:Version=0.9.${{ github.run_number }} -p:PackageId=Umbraco.Tools.CmsPackager
 
       - name: Push package to NuGet
         run: dotnet nuget push **/*.nupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Pack NuGet package
-        run: dotnet pack ./src/ --configuration Release
+        run: dotnet pack ./src/ --configuration Release --version-suffix ${{ github.run_number }}
 
       - name: Push package to NuGet
         run: dotnet nuget push **/*.nupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: Build and deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+        
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+    
+    - name: Build with dotnet
+      run: dotnet build --configuration Release
+
+  deploy: 
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Pack NuGet package
+        run: dotnet pack --configuration Release
+
+      - name: Push package to NuGet
+        run: dotnet nuget push **/*.nupkg
+              --api-key ${{ secrets.NUGET_DEPLOY_KEY }}
+              --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Pack NuGet package
-        run: dotnet pack ./src/ --configuration Release -p:Version=0.9.${{ github.run_number }} -p:PackageId=Umbraco.Tools.CmsPackager
+        run: dotnet pack ./src/ --configuration Release -p:Version=0.9.${{ github.run_number }} -p:PackageId=Jesper.Tools.CmsPackager
 
       - name: Push package to NuGet
         run: dotnet nuget push **/*.nupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
@@ -27,7 +26,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Pack NuGet package
-        run: dotnet pack ./src/ --configuration Release -p:Version=0.9.${{ github.run_number }} -p:PackageId=Jesper.Tools.CmsPackager
+        run: dotnet pack ./src/ 
+              --configuration Release 
+              -p:Version=0.9.${{ github.run_number }} 
+              -p:PackageId=Umbraco.Tools.Packages
 
       - name: Push package to NuGet
         run: dotnet nuget push **/*.nupkg

--- a/src/UmbPack.csproj
+++ b/src/UmbPack.csproj
@@ -18,6 +18,8 @@
     <PackageTags>Umbraco</PackageTags>
     <Version>0.9.0</Version>
     <RootNamespace>UmbPack</RootNamespace>     
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UmbPack.csproj
+++ b/src/UmbPack.csproj
@@ -14,7 +14,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <InformationalVersion>1.0.1.0</InformationalVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageTags>Umbraco</PackageTags>
     <Version>0.9.0</Version>
     <RootNamespace>UmbPack</RootNamespace>     

--- a/src/UmbPack.csproj
+++ b/src/UmbPack.csproj
@@ -20,7 +20,6 @@
     <RootNamespace>UmbPack</RootNamespace>     
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UmbPack.csproj
+++ b/src/UmbPack.csproj
@@ -20,6 +20,7 @@
     <RootNamespace>UmbPack</RootNamespace>     
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a Github action that build the tool and pushes it to Nuget.

It requires a secret set on the repo called `NUGET_DEPLOY_KEY` which contains a NuGet api key.
It will auto increment the patch version for each build and push. 

You can find an example of it running on my fork: https://github.com/jmayntzhusen/UmbPack/actions/runs/109076530

And can see the package being pushed successfully to my personal NuGet: https://www.nuget.org/packages/Jesper.Tools.CmsPackager/

(Under a different namespace as Umbraco.Tools is reserved)

The tool on NuGet will be called `Umbraco.Tools.Packages`, and will start on a version 0.9.x while we gather feedback and write documentation.