### PR TITLE
Show real name and version in helptext

### DIFF
--- a/src/UmbPack.csproj
+++ b/src/UmbPack.csproj
@@ -9,11 +9,10 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
 
     <AssemblyName>UmbPack</AssemblyName>
-    <AssemblyTitle>Umbraco Package CLI</AssemblyTitle>
+    <AssemblyTitle>UmbPack</AssemblyTitle>
     <Company>The Umbraco Community</Company>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <InformationalVersion>1.0.1.0</InformationalVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageTags>Umbraco</PackageTags>
     <Version>0.9.0</Version>


### PR DESCRIPTION
This fixes #14

The helptext generator took some default values from the csproj file. With these changes it will look like this:

![image](https://user-images.githubusercontent.com/36075913/82422194-6f2f0580-9a82-11ea-8ddf-53eb5a9c0ec6.png)
