### PR TITLE
Pass along package version from xml

### DIFF
--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -77,12 +77,12 @@ namespace Umbraco.Packager.CI.Verbs
             var packageInfo = Parse.PackageXml(filePath);
 
             // OK all checks passed - time to upload it
-            await UploadPackage(options, packageHelper);
+            await UploadPackage(options, packageHelper, packageInfo);
 
             return 0;
         }
 
-        private static async Task UploadPackage(PushOptions options, PackageHelper packageHelper)
+        private static async Task UploadPackage(PushOptions options, PackageHelper packageHelper, PackageInfo packageInfo)
         {
             try
             {
@@ -117,6 +117,7 @@ namespace Umbraco.Packager.CI.Verbs
                     form.Add(new StringContent(options.DotNetVersion), "dotNetVersion");
                     form.Add(new StringContent("package"), "fileType");
                     form.Add(GetVersionCompatibility(options.WorksWith), "umbracoVersions");
+                    form.Add(new StringContent(packageInfo.VersionString), "packageVersion");
 
                     var httpResponse = await client.PostAsync(url, form);
                     if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)


### PR DESCRIPTION
This PR ensures that on a `push` command it passes along the package version from the package.xml.

This is one of the requirements to fix https://github.com/umbraco/UmbPack/issues/17, other part of the fix is https://github.com/umbraco/OurUmbraco/pull/590