### PR TITLE
Add archive flag

### DIFF
--- a/src/PackageHelper.cs
+++ b/src/PackageHelper.cs
@@ -116,7 +116,7 @@ namespace Umbraco.Packager.CI
             }
         }
 
-        public async Task ArchivePackageFiles(ApiKeyModel keyParts, int[] ids)
+        public async Task ArchivePackages(ApiKeyModel keyParts, int[] ids)
         {
             var url = "Umbraco/Api/ProjectUpload/ArchiveProjectFiles";
             try

--- a/src/PackageHelper.cs
+++ b/src/PackageHelper.cs
@@ -116,6 +116,28 @@ namespace Umbraco.Packager.CI
             }
         }
 
+        public async Task ArchivePackageFiles(ApiKeyModel keyParts, int[] ids)
+        {
+            var url = "Umbraco/Api/ProjectUpload/ArchiveProjectFiles";
+            try
+            {
+                using (var httpClient = GetClientBase(url, keyParts.Token, keyParts.MemberId, keyParts.ProjectId))
+                {
+                    var httpResponse = await httpClient.PostAsJsonAsync(url, new { ids });
+
+                    if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        WriteError(Resources.Push_ApiKeyInvalid);
+                        Environment.Exit(5); // ERROR_ACCESS_DENIED
+                    }
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                throw ex;
+            }
+        }
+
         /// <summary>
         ///  change the colour of the console, write an error and reset the colour back.
         /// </summary>

--- a/src/PackageHelper.cs
+++ b/src/PackageHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
@@ -116,7 +117,7 @@ namespace Umbraco.Packager.CI
             }
         }
 
-        public async Task ArchivePackages(ApiKeyModel keyParts, int[] ids)
+        public async Task ArchivePackages(ApiKeyModel keyParts, IEnumerable<int> ids)
         {
             var url = "Umbraco/Api/ProjectUpload/ArchiveProjectFiles";
             try

--- a/src/PackageHelper.cs
+++ b/src/PackageHelper.cs
@@ -124,7 +124,7 @@ namespace Umbraco.Packager.CI
             {
                 using (var httpClient = GetClientBase(url, keyParts.Token, keyParts.MemberId, keyParts.ProjectId))
                 {
-                    var httpResponse = await httpClient.PostAsJsonAsync(url, new { ids });
+                    var httpResponse = await httpClient.PostAsJsonAsync(url, ids);
 
                     if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
                     {

--- a/src/PackageHelper.cs
+++ b/src/PackageHelper.cs
@@ -138,6 +138,31 @@ namespace Umbraco.Packager.CI
                 throw ex;
             }
         }
+        
+        public async Task<string> GetCurrentPackageFileId(ApiKeyModel keyParts)
+        {
+            var url = "Umbraco/Api/ProjectUpload/GetCurrentPackageFileId";
+            try
+            {
+                using (var httpClient = GetClientBase(url, keyParts.Token, keyParts.MemberId, keyParts.ProjectId))
+                {
+                    var httpResponse = await httpClient.GetAsync(url);
+
+                    if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        WriteError(Resources.Push_ApiKeyInvalid);
+                        Environment.Exit(5); // ERROR_ACCESS_DENIED
+                    }
+
+                    var apiResponse = await httpResponse.Content.ReadAsStringAsync();
+                    return apiResponse;
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                throw ex;
+            }
+        }
 
         /// <summary>
         ///  change the colour of the console, write an error and reset the colour back.

--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -141,6 +141,14 @@ namespace Umbraco.Packager.CI.Properties{
             }
         }
         
+        ///   Looks up a localized string similar to A wildcard pattern to match against existing package files to archive.
+        /// </summary>
+        public static string HelpPushArchive {
+            get {
+                return ResourceManager.GetString("HelpPushArchive", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Change the required DotNetVersion for the package.
         /// </summary>

--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -141,7 +141,8 @@ namespace Umbraco.Packager.CI.Properties{
             }
         }
         
-        ///   Looks up a localized string similar to A wildcard pattern to match against existing package files to archive.
+        /// <summary>
+        ///   Looks up a localized string similar to One or more wildcard patterns to match against existing package files to be archived.
         /// </summary>
         public static string HelpPushArchive {
             get {

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -144,6 +144,9 @@
   <data name="HelpPushCurrent" xml:space="preserve">
     <value>Make this package the current package file</value>
   </data>
+  <data name="HelpPushArchive" xml:space="preserve">
+    <value>A wildcard pattern to match against existing package files to archive</value>
+  </data>
   <data name="HelpPushDotNet" xml:space="preserve">
     <value>Change the required DotNetVersion for the package</value>
   </data>

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -145,7 +145,7 @@
     <value>Make this package the current package file</value>
   </data>
   <data name="HelpPushArchive" xml:space="preserve">
-    <value>A wildcard pattern to match against existing package files to archive</value>
+    <value>One or more wildcard patterns to match against existing package files to be archived</value>
   </data>
   <data name="HelpPushDotNet" xml:space="preserve">
     <value>Change the required DotNetVersion for the package</value>

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -79,16 +79,28 @@ namespace Umbraco.Packager.CI.Verbs
             }
 
             // Archive packages
-            // TODO: Once a current flag is introduced, we can check that instead
+            var archivePatterns = new List<string>();
             var packagesToArchive = new List<int>();
 
             if (options.Archive != null)
             {
-                foreach (var archive in options.Archive)
+                archivePatterns.AddRange(options.Archive);
+            }
+
+            // TODO: Once a "Current" option is introduced, which makes the current package being upload "Current"
+            // then uncomment the following lines
+            //if (options.Current && !archivePatterns.Contains("current"))
+            //{
+            //    archivePatterns.Add("current");
+            //}
+
+            if (archivePatterns.Count > 0)
+            {
+                foreach (var archivePattern in archivePatterns)
                 {
-                    if (archive == "current")
+                    if (archivePattern == "current")
                     {
-                        // If the archive option is "current" (default), then archive the current package
+                        // If the archive option is "current", then archive the current package
                         var currentPackage = packages.FirstOrDefault(x => x.Value<bool>("Current"));
                         if (currentPackage != null)
                         {
@@ -98,7 +110,7 @@ namespace Umbraco.Packager.CI.Verbs
                     else
                     {
                         // Convert the archive option to a regex
-                        var archiveRegex = new Regex("^" + archive.Replace(".", "\\.").Replace("*", "(.*)") + "$", RegexOptions.IgnoreCase);
+                        var archiveRegex = new Regex("^" + archivePattern.Replace(".", "\\.").Replace("*", "(.*)") + "$", RegexOptions.IgnoreCase);
 
                         // Find packages that match the regex and extract their IDs
                         var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -101,7 +101,8 @@ namespace Umbraco.Packager.CI.Verbs
                     if (archivePattern == "current")
                     {
                         // If the archive option is "current", then archive the current package
-                        packagesToArchive.Add(int.Parse(currentPackageId));
+                        if (currentPackageId != "0")
+                            packagesToArchive.Add(int.Parse(currentPackageId));
                     }
                     else
                     {

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -39,6 +39,10 @@ namespace Umbraco.Packager.CI.Verbs
         [Option('w', "WorksWith", Default = "v850", 
             HelpText = "HelpPushWorks", ResourceType = typeof(HelpTextResource))]
         public string WorksWith { get; set; }
+
+        [Option('a', "Archive", 
+            HelpText = "HelpPushArchive", ResourceType = typeof(HelpTextResource))]
+        public string Archive { get; set; }
     }
 
 

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -42,7 +42,7 @@ namespace Umbraco.Packager.CI.Verbs
             HelpText = "HelpPushWorks", ResourceType = typeof(HelpTextResource))]
         public string WorksWith { get; set; }
 
-        [Option('a', "Archive", 
+        [Option('a', "Archive", Separator = ' ', 
             HelpText = "HelpPushArchive", ResourceType = typeof(HelpTextResource))]
         public IEnumerable<string> Archive { get; set; }
     }
@@ -87,12 +87,11 @@ namespace Umbraco.Packager.CI.Verbs
                 archivePatterns.AddRange(options.Archive);
             }
 
-            // TODO: Once a "Current" option is introduced, which makes the current package being upload "Current"
-            // then uncomment the following lines
-            //if (options.Current && !archivePatterns.Contains("current"))
-            //{
-            //    archivePatterns.Add("current");
-            //}
+            // if the new package will be set to current, archive the previous current package
+            // if (options.Current == "true" && !archivePatterns.Contains("current"))
+            // {
+            //     archivePatterns.Add("current");
+            // }
 
             if (archivePatterns.Count > 0)
             {

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -82,26 +82,29 @@ namespace Umbraco.Packager.CI.Verbs
             // TODO: Once a current flag is introduced, we can check that instead
             var packagesToArchive = new List<int>();
 
-            foreach (var archive in options.Archive)
+            if (options.Archive != null)
             {
-                if (archive == "current")
+                foreach (var archive in options.Archive)
                 {
-                    // If the archive option is "current" (default), then archive the current package
-                    var currentPackage = packages.FirstOrDefault(x => x.Value<bool>("Current"));
-                    if (currentPackage != null)
+                    if (archive == "current")
                     {
-                        packagesToArchive.Add(currentPackage.Value<int>("Id"));
+                        // If the archive option is "current" (default), then archive the current package
+                        var currentPackage = packages.FirstOrDefault(x => x.Value<bool>("Current"));
+                        if (currentPackage != null)
+                        {
+                            packagesToArchive.Add(currentPackage.Value<int>("Id"));
+                        }
                     }
-                }
-                else
-                {
-                    // Convert the archive option to a regex
-                    var archiveRegex = new Regex("^" + archive.Replace(".", "\\.").Replace("*", "(.*)") + "$", RegexOptions.IgnoreCase);
+                    else
+                    {
+                        // Convert the archive option to a regex
+                        var archiveRegex = new Regex("^" + archive.Replace(".", "\\.").Replace("*", "(.*)") + "$", RegexOptions.IgnoreCase);
 
-                    // Find packages that match the regex and extract their IDs
-                    var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();
+                        // Find packages that match the regex and extract their IDs
+                        var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();
 
-                    packagesToArchive.AddRange(archiveIds);
+                        packagesToArchive.AddRange(archiveIds);
+                    }
                 }
             }
 

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -72,6 +72,7 @@ namespace Umbraco.Packager.CI.Verbs
             // gets a package list from our.umbraco
             // if the api key is invalid we will also find out here.
             var packages = await packageHelper.GetPackageList(keyParts);
+            var currentPackageId = await packageHelper.GetCurrentPackageFileId(keyParts);
 
             if (packages != null)
             { 
@@ -88,10 +89,10 @@ namespace Umbraco.Packager.CI.Verbs
             }
 
             // if the new package will be set to current, archive the previous current package
-            // if (options.Current == "true" && !archivePatterns.Contains("current"))
-            // {
-            //     archivePatterns.Add("current");
-            // }
+            if (options.Current == "true" && !archivePatterns.Contains("current"))
+            {
+                archivePatterns.Add("current");
+            }
 
             if (archivePatterns.Count > 0)
             {
@@ -100,11 +101,7 @@ namespace Umbraco.Packager.CI.Verbs
                     if (archivePattern == "current")
                     {
                         // If the archive option is "current", then archive the current package
-                        var currentPackage = packages.FirstOrDefault(x => x.Value<bool>("Current"));
-                        if (currentPackage != null)
-                        {
-                            packagesToArchive.Add(currentPackage.Value<int>("Id"));
-                        }
+                        packagesToArchive.Add(int.Parse(currentPackageId));
                     }
                     else
                     {
@@ -122,6 +119,7 @@ namespace Umbraco.Packager.CI.Verbs
             if (packagesToArchive.Count > 0)
             {
                 await packageHelper.ArchivePackages(keyParts, packagesToArchive.Distinct());
+                Console.WriteLine($"Archived {packagesToArchive.Count} packages matching the archive pattern.");
             }
 
             // Parse package.xml before upload to print out info

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -78,13 +78,14 @@ namespace Umbraco.Packager.CI.Verbs
             }
 
             // Archive packages
+            // TODO: Once a current flag is introduced, we can check that instead
             if (options.Archive == "current")
             {
                 // If the archive option is "current" (default), then archive the current package
                 var currentPackage = packages.FirstOrDefault(x => x.Value<bool>("Current"));
                 if (currentPackage != null)
                 {
-                    await ArchivePackages(new[] { currentPackage.Value<int>("Id") });
+                    await packageHelper.ArchivePackageFiles(keyParts, new[] { currentPackage.Value<int>("Id") });
                 }
             }
             else
@@ -95,7 +96,7 @@ namespace Umbraco.Packager.CI.Verbs
                 // Find packages that match the regex and extract their IDs
                 var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();
 
-                await ArchivePackages(archiveIds);
+                await packageHelper.ArchivePackageFiles(keyParts, archiveIds);
             }
 
             // Parse package.xml before upload to print out info
@@ -169,10 +170,6 @@ namespace Umbraco.Packager.CI.Verbs
             }
         }
 
-        private static async Task ArchivePackages(int[] id)
-        {
-
-        }
 
         /// <summary>
         ///  returns the version compatibility string for uploading the package

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -88,12 +88,6 @@ namespace Umbraco.Packager.CI.Verbs
                 archivePatterns.AddRange(options.Archive);
             }
 
-            // if the new package will be set to current, archive the previous current package
-            if (options.Current == "true" && !archivePatterns.Contains("current"))
-            {
-                archivePatterns.Add("current");
-            }
-
             if (archivePatterns.Count > 0)
             {
                 foreach (var archivePattern in archivePatterns)

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Handlers;
 using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using CommandLine;
@@ -40,7 +41,7 @@ namespace Umbraco.Packager.CI.Verbs
             HelpText = "HelpPushWorks", ResourceType = typeof(HelpTextResource))]
         public string WorksWith { get; set; }
 
-        [Option('a', "Archive", 
+        [Option('a', "Archive", Default = "current",
             HelpText = "HelpPushArchive", ResourceType = typeof(HelpTextResource))]
         public string Archive { get; set; }
     }
@@ -74,6 +75,27 @@ namespace Umbraco.Packager.CI.Verbs
             if (packages != null)
             { 
                 packageHelper.EnsurePackageDoesntAlreadyExists(packages, filePath);
+            }
+
+            // Archive packages
+            if (options.Archive == "current")
+            {
+                // If the archive option is "current" (default), then archive the current package
+                var currentPackage = packages.FirstOrDefault(x => x.Value<bool>("Current"));
+                if (currentPackage != null)
+                {
+                    await ArchivePackages(new[] { currentPackage.Value<int>("Id") });
+                }
+            }
+            else
+            {
+                // Convert the archive option to a regex
+                var archiveRegex = new Regex("^" + options.Archive.Replace(".", "\\.").Replace("*", "(.*)") + "$", RegexOptions.IgnoreCase);
+
+                // Find packages that match the regex and extract their IDs
+                var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();
+
+                await ArchivePackages(archiveIds);
             }
 
             // Parse package.xml before upload to print out info
@@ -147,7 +169,10 @@ namespace Umbraco.Packager.CI.Verbs
             }
         }
 
+        private static async Task ArchivePackages(int[] id)
+        {
 
+        }
 
         /// <summary>
         ///  returns the version compatibility string for uploading the package

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -85,7 +85,7 @@ namespace Umbraco.Packager.CI.Verbs
                 var currentPackage = packages.FirstOrDefault(x => x.Value<bool>("Current"));
                 if (currentPackage != null)
                 {
-                    await packageHelper.ArchivePackageFiles(keyParts, new[] { currentPackage.Value<int>("Id") });
+                    await packageHelper.ArchivePackages(keyParts, new[] { currentPackage.Value<int>("Id") });
                 }
             }
             else
@@ -96,7 +96,7 @@ namespace Umbraco.Packager.CI.Verbs
                 // Find packages that match the regex and extract their IDs
                 var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();
 
-                await packageHelper.ArchivePackageFiles(keyParts, archiveIds);
+                await packageHelper.ArchivePackages(keyParts, archiveIds);
             }
 
             // Parse package.xml before upload to print out info


### PR DESCRIPTION
This PR adds a `-a` flag to UmbPack Push verb to archive packages on push

Supported values are "current" which is the default, which will archive whatever package is currently set to be the "Current", otherwise it's assumed the value is a simple wildcard pattern match such as `My.Package.*.zip`. 

Fixes #18 