### PR TITLE
Rename internal Publish flag to Current

### DIFF
--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Umbraco.Packager.CI.Properties {
+namespace Umbraco.Packager.CI.Properties{
     using System;
     
     
@@ -19,7 +19,7 @@ namespace Umbraco.Packager.CI.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class HelpTextResource {
@@ -133,6 +133,15 @@ namespace Umbraco.Packager.CI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Make this package the current package file.
+        /// </summary>
+        public static string HelpPushCurrent {
+            get {
+                return ResourceManager.GetString("HelpPushCurrent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change the required DotNetVersion for the package.
         /// </summary>
         public static string HelpPushDotNet {
@@ -156,15 +165,6 @@ namespace Umbraco.Packager.CI.Properties {
         public static string HelpPushPackage {
             get {
                 return ResourceManager.GetString("HelpPushPackage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Make this package the current package file.
-        /// </summary>
-        public static string HelpPushPublish {
-            get {
-                return ResourceManager.GetString("HelpPushPublish", resourceCulture);
             }
         }
         

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -141,6 +141,9 @@
   <data name="HelpPush" xml:space="preserve">
     <value>Push an Umbraco package to our.umbraco.com</value>
   </data>
+  <data name="HelpPushCurrent" xml:space="preserve">
+    <value>Make this package the current package file</value>
+  </data>
   <data name="HelpPushDotNet" xml:space="preserve">
     <value>Change the required DotNetVersion for the package</value>
   </data>
@@ -149,9 +152,6 @@
   </data>
   <data name="HelpPushPackage" xml:space="preserve">
     <value>Path to the package.zip you wish to push</value>
-  </data>
-  <data name="HelpPushPublish" xml:space="preserve">
-    <value>Make this package the current package file</value>
   </data>
   <data name="HelpPushWorks" xml:space="preserve">
     <value>Compatible Umbraco versions (in the form v850,v840,v830)</value>

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -29,8 +29,8 @@ namespace Umbraco.Packager.CI.Verbs
         public string ApiKey { get; set; }
 
         [Option('c', "Current", Default = "true", 
-            HelpText = "HelpPushPublish", ResourceType = typeof(HelpTextResource))]
-        public string Publish { get; set; }
+            HelpText = "HelpPushCurrent", ResourceType = typeof(HelpTextResource))]
+        public string Current { get; set; }
 
         [Option("DotNetVersion", Default = "4.7.2", 
             HelpText = "HelpPushDotNet", ResourceType = typeof(HelpTextResource))]
@@ -113,7 +113,7 @@ namespace Umbraco.Packager.CI.Verbs
                         FileName = fileInfo.Name
                     };
                     form.Add(content);
-                    form.Add(new StringContent(ParsePublishFlag(options.Publish)), "isCurrent");
+                    form.Add(new StringContent(ParseCurrentFlag(options.Current)), "isCurrent");
                     form.Add(new StringContent(options.DotNetVersion), "dotNetVersion");
                     form.Add(new StringContent("package"), "fileType");
                     form.Add(GetVersionCompatibility(options.WorksWith), "umbracoVersions");
@@ -161,9 +161,9 @@ namespace Umbraco.Packager.CI.Verbs
             return new StringContent(JsonConvert.SerializeObject(versions));
         }
 
-        private static string ParsePublishFlag(string publish)
+        private static string ParseCurrentFlag(string current)
         {
-            if (bool.TryParse(publish, out bool result))
+            if (bool.TryParse(current, out bool result))
             {
                 return result.ToString();
             }


### PR DESCRIPTION
Fixes #30 renaming the internal Publish option (which relates to the -c current command line arg) to be Current for consistency