### PR TITLE
Override package filename

### DIFF
--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -12,5 +12,28 @@ namespace Umbraco.Packager.CI.Extensions
         {
             return str.ToString((IFormatProvider) CultureInfo.InvariantCulture);
         }
+
+        /// <summary>
+        /// Ensures an input string starts with the supplied value
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="toStartWith"></param>
+        /// <returns></returns>
+        public static string EnsureStartsWith(this string input, string toStartWith)
+        {
+            return input.StartsWith(toStartWith) ? input : toStartWith + input;
+        }
+
+        /// <summary>
+        /// Ensures an input string ends with the supplied value
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="toEndWith"></param>
+        /// <returns></returns>
+        public static string EnsureEndsWith(this string input, string toEndWith)
+        {
+            return input.EndsWith(toEndWith) ? input : input + toEndWith;
+        }
+
     }
 }

--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -8,7 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Umbraco.Packager.CI.Properties{
+namespace Umbraco.Packager.CI.Properties
+{
     using System;
     
     
@@ -106,6 +107,15 @@ namespace Umbraco.Packager.CI.Properties{
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An explicit file name to give the generated package file.
+        /// </summary>
+        public static string HelpPackFileName {
+            get {
+                return ResourceManager.GetString("HelpPackFileName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specified the directory the created package will be saved to.
         /// </summary>
         public static string HelpPackOutput {
@@ -133,20 +143,20 @@ namespace Umbraco.Packager.CI.Properties{
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make this package the current package file.
-        /// </summary>
-        public static string HelpPushCurrent {
-            get {
-                return ResourceManager.GetString("HelpPushCurrent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to One or more wildcard patterns to match against existing package files to be archived.
         /// </summary>
         public static string HelpPushArchive {
             get {
                 return ResourceManager.GetString("HelpPushArchive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Make this package the current package file.
+        /// </summary>
+        public static string HelpPushCurrent {
+            get {
+                return ResourceManager.GetString("HelpPushCurrent", resourceCulture);
             }
         }
         

--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -107,20 +107,20 @@ namespace Umbraco.Packager.CI.Properties
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An explicit file name to give the generated package file.
-        /// </summary>
-        public static string HelpPackFileName {
-            get {
-                return ResourceManager.GetString("HelpPackFileName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Specified the directory the created package will be saved to.
         /// </summary>
         public static string HelpPackOutput {
             get {
                 return ResourceManager.GetString("HelpPackOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An explicit file name to give the generated package file.
+        /// </summary>
+        public static string HelpPackPackageFileName {
+            get {
+                return ResourceManager.GetString("HelpPackPackageFileName", resourceCulture);
             }
         }
         

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -159,7 +159,7 @@
   <data name="HelpPushWorks" xml:space="preserve">
     <value>Compatible Umbraco versions (in the form v850,v840,v830)</value>
   </data>
-  <data name="HelpPackFileName" xml:space="preserve">
+  <data name="HelpPackPackageFileName" xml:space="preserve">
     <value>An explicit file name to give the generated package file</value>
   </data>
 </root>

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -159,4 +159,7 @@
   <data name="HelpPushWorks" xml:space="preserve">
     <value>Compatible Umbraco versions (in the form v850,v840,v830)</value>
   </data>
+  <data name="HelpPackFileName" xml:space="preserve">
+    <value>An explicit file name to give the generated package file</value>
+  </data>
 </root>

--- a/src/Verbs/PackCommand.cs
+++ b/src/Verbs/PackCommand.cs
@@ -28,10 +28,10 @@ namespace Umbraco.Packager.CI.Verbs
             ResourceType = typeof(HelpTextResource))]
         public string Version { get; set; }
 
-        [Option('n', "FileName",
-            HelpText = "HelpPackFileName",
+        [Option('n', "PackageFileName",
+            HelpText = "HelpPackPackageFileName",
             ResourceType = typeof(HelpTextResource))]
-        public string FileName { get; set; }
+        public string PackageFileName { get; set; }
     }
 
 
@@ -108,8 +108,8 @@ namespace Umbraco.Packager.CI.Verbs
             Console.WriteLine(Resources.Pack_GetPackageName);
 
             // work out what we are going to call the package
-            var packageFileName = !string.IsNullOrWhiteSpace(options.FileName)
-                ? options.FileName
+            var packageFileName = !string.IsNullOrWhiteSpace(options.PackageFileName)
+                ? options.PackageFileName
                 : GetPackageFileName(options.OutputDirectory, packageXml, version);
 
             Console.WriteLine(Resources.Pack_AddPackageFiles);

--- a/src/Verbs/PackCommand.cs
+++ b/src/Verbs/PackCommand.cs
@@ -27,6 +27,11 @@ namespace Umbraco.Packager.CI.Verbs
             HelpText = "HelpPackVersion",
             ResourceType = typeof(HelpTextResource))]
         public string Version { get; set; }
+
+        [Option('n', "FileName",
+            HelpText = "HelpPackFileName",
+            ResourceType = typeof(HelpTextResource))]
+        public string FileName { get; set; }
     }
 
 
@@ -101,8 +106,11 @@ namespace Umbraco.Packager.CI.Verbs
             var version = GetOrSetPackageVersion(packageXml, options.Version);
 
             Console.WriteLine(Resources.Pack_GetPackageName);
+
             // work out what we are going to call the package
-            var packageFileName = GetPackageFileName(options.OutputDirectory, packageXml, version);
+            var packageFileName = !string.IsNullOrWhiteSpace(options.FileName)
+                ? options.FileName
+                : GetPackageFileName(options.OutputDirectory, packageXml, version);
 
             Console.WriteLine(Resources.Pack_AddPackageFiles);
             // add any files based on what is already in the package.xml


### PR DESCRIPTION
Fixed #36 by introducing a `-n` flag to allow you to override the package file name generated by the pack command

    umpack pack path/to/package.xml -v 1.0.0 -o output/directory -n MyPackage.1.0.0.zip