### PR TITLE
Add replaceable properties to the pack command

### DIFF
--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -8,7 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Umbraco.Packager.CI.Properties{
+namespace Umbraco.Packager.CI.Properties
+{
     using System;
     
     
@@ -115,6 +116,15 @@ namespace Umbraco.Packager.CI.Properties{
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Properties to replace in the package file.
+        /// </summary>
+        public static string HelpPackProperties {
+            get {
+                return ResourceManager.GetString("HelpPackProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Override the version defined in the package.xml file.
         /// </summary>
         public static string HelpPackVersion {
@@ -133,20 +143,20 @@ namespace Umbraco.Packager.CI.Properties{
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make this package the current package file.
-        /// </summary>
-        public static string HelpPushCurrent {
-            get {
-                return ResourceManager.GetString("HelpPushCurrent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to One or more wildcard patterns to match against existing package files to be archived.
         /// </summary>
         public static string HelpPushArchive {
             get {
                 return ResourceManager.GetString("HelpPushArchive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Make this package the current package file.
+        /// </summary>
+        public static string HelpPushCurrent {
+            get {
+                return ResourceManager.GetString("HelpPushCurrent", resourceCulture);
             }
         }
         

--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -116,7 +116,7 @@ namespace Umbraco.Packager.CI.Properties
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties to replace in the package file.
+        ///   Looks up a localized string similar to Properties to replace in the package.xml file.
         /// </summary>
         public static string HelpPackProperties {
             get {

--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -195,5 +195,14 @@ namespace Umbraco.Packager.CI.Properties
                 return ResourceManager.GetString("HelpPushWorks", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   List of properties to replace in the package.xml
+        /// </summary>
+        public static string HelpPackProperties {
+            get {
+                return ResourceManager.GetString("HelpPackProperties", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -160,6 +160,6 @@
     <value>Compatible Umbraco versions (in the form v850,v840,v830)</value>
   </data>
   <data name="HelpPackProperties" xml:space="preserve">
-    <value>Properties to replace in the package file</value>
+    <value>Properties to replace in the package.xml file</value>
   </data>
 </root>

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -159,4 +159,7 @@
   <data name="HelpPushWorks" xml:space="preserve">
     <value>Compatible Umbraco versions (in the form v850,v840,v830)</value>
   </data>
+  <data name="HelpPackProperties" xml:space="preserve">
+    <value>Properties to replace in the package file</value>
+  </data>
 </root>

--- a/src/Verbs/PackCommand.cs
+++ b/src/Verbs/PackCommand.cs
@@ -99,11 +99,12 @@ namespace Umbraco.Packager.CI.Verbs
             Console.WriteLine(Resources.Pack_LoadingFile, packageFile);
 
             // load the package xml
-            var packageXmlContents = File.ReadAllText(packageFile);
+            XElement packageXml = null;
 
-            // Replace property tokens
             if (!string.IsNullOrWhiteSpace(options.Properties))
             {
+                var packageXmlContents = File.ReadAllText(packageFile);
+
                 var props = options.Properties.Split(";", StringSplitOptions.RemoveEmptyEntries)
                     .Select(x => x.Split('='))
                     .ToDictionary(x => x[0], x => x[1]);
@@ -112,10 +113,13 @@ namespace Umbraco.Packager.CI.Verbs
                 {
                     packageXmlContents = packageXmlContents.Replace($"${prop.Key}$", prop.Value);
                 }
-            }
 
-            // Parse the package XML contents
-            var packageXml = XElement.Parse(packageXmlContents);
+                packageXml = XElement.Parse(packageXmlContents);
+            }
+            else
+            {
+                packageXml = XElement.Load(packageFile);
+            }
 
             Console.WriteLine(Resources.Pack_UpdatingVersion);
 


### PR DESCRIPTION
This PR fixes #35 by adding a new `-p` option that accepts a series of name value pairs where the name defines a key that should be replaced in the package.xml file and the value defines the replacement value.

    umbpack pack path/to/package.xml -p MyProp1=Val1;MyProp2=Val2

With the above command, any text tokens for `$MyProp1$` and `$MyProp2$` in the package.xml will be replaces with Val1 and Val2 values accordingly.