### PR TITLE
adds flag to skip duplicate filenames, adds writewarning function,

### DIFF
--- a/src/PackageHelper.cs
+++ b/src/PackageHelper.cs
@@ -185,10 +185,10 @@ namespace Umbraco.Packager.CI
         /// <summary>
         ///  change the colour of the console, write a warning and reset the colour back.
         /// </summary>
-        public void WriteWarning(string error, params object[] parameters)
+        public void WriteWarning(string warning, params object[] parameters)
         {
             Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine(error, parameters);
+            Console.WriteLine(warning, parameters);
             Console.ResetColor();
         }
 

--- a/src/PackageHelper.cs
+++ b/src/PackageHelper.cs
@@ -100,19 +100,27 @@ namespace Umbraco.Packager.CI
             return null;
         }
 
-        public void EnsurePackageDoesntAlreadyExists(JArray packages, string packageFile)
+        public void EnsurePackageDoesntAlreadyExists(JArray packages, string packageFile, bool skipDuplicates = false)
         {
             if (packages == null) return;
 
             var packageFileName = Path.GetFileName(packageFile);
 
-            foreach(var package in packages)
+            foreach (var package in packages)
             {
-                var packageName = package.Value<string>("Name"); 
+                var packageName = package.Value<string>("Name");
                 if (packageName.Equals(packageFileName, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    WriteError(Resources.Push_PackageExists, packageFileName);
-                    Environment.Exit(80); // FILE_EXISTS
+                    if (skipDuplicates)
+                    {
+                        WriteWarning(Resources.Push_PackageSkipped, packageFileName);
+                        Environment.Exit(0);
+                    }
+                    else
+                    {
+                        WriteError(Resources.Push_PackageExists, packageFileName);
+                        Environment.Exit(80); // FILE_EXISTS                
+                    }
                 }
             }
         }
@@ -171,6 +179,16 @@ namespace Umbraco.Packager.CI
         {
             Console.ForegroundColor = ConsoleColor.Red;
             Console.Error.WriteLine(error, parameters);
+            Console.ResetColor();
+        }
+
+        /// <summary>
+        ///  change the colour of the console, write a warning and reset the colour back.
+        /// </summary>
+        public void WriteWarning(string error, params object[] parameters)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine(error, parameters);
             Console.ResetColor();
         }
 

--- a/src/Properties/HelpTextResource.Designer.cs
+++ b/src/Properties/HelpTextResource.Designer.cs
@@ -8,8 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Umbraco.Packager.CI.Properties
-{
+namespace Umbraco.Packager.CI.Properties {
     using System;
     
     
@@ -184,6 +183,15 @@ namespace Umbraco.Packager.CI.Properties
         public static string HelpPushPackage {
             get {
                 return ResourceManager.GetString("HelpPushPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ignore duplicate package names.
+        /// </summary>
+        public static string HelpPushSkipDuplicates {
+            get {
+                return ResourceManager.GetString("HelpPushSkipDuplicates", resourceCulture);
             }
         }
         

--- a/src/Properties/HelpTextResource.resx
+++ b/src/Properties/HelpTextResource.resx
@@ -162,4 +162,7 @@
   <data name="HelpPackPackageFileName" xml:space="preserve">
     <value>An explicit file name to give the generated package file</value>
   </data>
+  <data name="HelpPushSkipDuplicates" xml:space="preserve">
+    <value>Ignore duplicate package names</value>
+  </data>
 </root>

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Packager.CI.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -89,7 +89,7 @@ namespace Umbraco.Packager.CI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to For more information see ?? .
+        ///   Looks up a localized string similar to For more information see https://our.umbraco.com/documentation/Extending/Packages/UmbPack .
         /// </summary>
         internal static string HelpFooter {
             get {
@@ -430,6 +430,15 @@ namespace Umbraco.Packager.CI.Properties {
         internal static string Push_PackageExists {
             get {
                 return ResourceManager.GetString("Push.PackageExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skipped pushing &apos;{0}&apos; - package file already exists.
+        /// </summary>
+        internal static string Push_PackageSkipped {
+            get {
+                return ResourceManager.GetString("Push.PackageSkipped", resourceCulture);
             }
         }
         

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -253,4 +253,7 @@ See https://our.umbraco.com/documentation/Extending/Packages/Creating-a-Package/
   <data name="Push.Uploading" xml:space="preserve">
     <value>Uploading {0} to our.umbraco.com ...</value>
   </data>
+  <data name="Push.PackageSkipped" xml:space="preserve">
+    <value>Skipped pushing '{0}' - package file already exists</value>
+  </data>
 </root>

--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using CommandLine;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Umbraco.Packager.CI.Auth;
 using Umbraco.Packager.CI.Properties;
 
@@ -30,21 +31,25 @@ namespace Umbraco.Packager.CI.Verbs
         [Option('k', "Key", HelpText = "HelpPushKey", ResourceType = typeof(HelpTextResource))]
         public string ApiKey { get; set; }
 
-        [Option('c', "Current", Default = "true", 
+        [Option('c', "Current", Default = "true",
             HelpText = "HelpPushCurrent", ResourceType = typeof(HelpTextResource))]
         public string Current { get; set; }
 
-        [Option("DotNetVersion", Default = "4.7.2", 
+        [Option("DotNetVersion", Default = "4.7.2",
             HelpText = "HelpPushDotNet", ResourceType = typeof(HelpTextResource))]
         public string DotNetVersion { get; set; }
 
-        [Option('w', "WorksWith", Default = "v850", 
+        [Option('w', "WorksWith", Default = "v850",
             HelpText = "HelpPushWorks", ResourceType = typeof(HelpTextResource))]
         public string WorksWith { get; set; }
 
-        [Option('a', "Archive", Separator = ' ', 
+        [Option('a', "Archive", Separator = ' ',
             HelpText = "HelpPushArchive", ResourceType = typeof(HelpTextResource))]
         public IEnumerable<string> Archive { get; set; }
+
+        [Option('s', "SkipDuplicates", Default = false,
+            HelpText = "HelpPushSkipDuplicates", ResourceType = typeof(HelpTextResource))]
+        public bool SkipDuplicates { get; set; }
     }
 
 
@@ -72,159 +77,181 @@ namespace Umbraco.Packager.CI.Verbs
             // gets a package list from our.umbraco
             // if the api key is invalid we will also find out here.
             var packages = await packageHelper.GetPackageList(keyParts);
-            var currentPackageId = await packageHelper.GetCurrentPackageFileId(keyParts);
 
             if (packages != null)
-            { 
-                packageHelper.EnsurePackageDoesntAlreadyExists(packages, filePath);
-            }
-
-            // Archive packages
-            var archivePatterns = new List<string>();
-            var packagesToArchive = new List<int>();
-
-            if (options.Archive != null)
             {
-                archivePatterns.AddRange(options.Archive);
+                packageHelper.EnsurePackageDoesntAlreadyExists(packages, filePath, options.SkipDuplicates);
             }
 
-            if (archivePatterns.Count > 0)
-            {
-                foreach (var archivePattern in archivePatterns)
-                {
-                    if (archivePattern == "current")
-                    {
-                        // If the archive option is "current", then archive the current package
-                        if (currentPackageId != "0")
-                            packagesToArchive.Add(int.Parse(currentPackageId));
-                    }
-                    else
-                    {
-                        // Convert the archive option to a regex
-                        var archiveRegex = new Regex("^" + archivePattern.Replace(".", "\\.").Replace("*", "(.*)") + "$", RegexOptions.IgnoreCase);
-
-                        // Find packages that match the regex and extract their IDs
-                        var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();
-
-                        packagesToArchive.AddRange(archiveIds);
-                    }
-                }
-            }
-
-            if (packagesToArchive.Count > 0)
-            {
-                await packageHelper.ArchivePackages(keyParts, packagesToArchive.Distinct());
-                Console.WriteLine($"Archived {packagesToArchive.Count} packages matching the archive pattern.");
-            }
+            await ArchivePackages(options, packageHelper, packages);
 
             // Parse package.xml before upload to print out info
             // and to use for comparison on what is already uploaded
             var packageInfo = Parse.PackageXml(filePath);
 
             // OK all checks passed - time to upload it
-            await UploadPackage(options, packageHelper, packageInfo);
+            await UploadPackage(options, packageHelper, packageInfo);   
 
             return 0;
         }
 
-        private static async Task UploadPackage(PushOptions options, PackageHelper packageHelper, PackageInfo packageInfo)
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="packageHelper"></param>
+    /// <param name="packages"></param>
+    /// <returns></returns>
+    private static async Task ArchivePackages(PushOptions options, PackageHelper packageHelper, JArray packages)
+    {
+        var keyParts = packageHelper.SplitKey(options.ApiKey);
+
+        // Archive packages
+        var archivePatterns = new List<string>();
+        var packagesToArchive = new List<int>();
+
+        var currentPackageId = await packageHelper.GetCurrentPackageFileId(keyParts);
+
+        if (options.Archive != null)
         {
-            try
+            archivePatterns.AddRange(options.Archive);
+        }
+
+        if (archivePatterns.Count > 0)
+        {
+            foreach (var archivePattern in archivePatterns)
             {
-                // HttpClient will use this event handler to give us
-                // Reporting on how its progress the file upload
-                var processMsgHandler = new ProgressMessageHandler(new HttpClientHandler());
-                processMsgHandler.HttpSendProgress += (sender, e) =>
+                if (archivePattern == "current")
                 {
-                    // Could try to reimplement progressbar - but that library did not work in GH Actions :(
-                    var percent = e.ProgressPercentage;
-                };
-
-                var keyParts = packageHelper.SplitKey(options.ApiKey);
-                var packageFileName = Path.GetFileName(options.Package);
-
-                Console.WriteLine(Resources.Push_Uploading, packageFileName);
-
-                var url = "/Umbraco/Api/ProjectUpload/UpdatePackage";
-
-                using (var client = packageHelper.GetClientBase(url, keyParts.Token, keyParts.MemberId, keyParts.ProjectId))
+                    // If the archive option is "current", then archive the current package
+                    if (currentPackageId != "0")
+                        packagesToArchive.Add(int.Parse(currentPackageId));
+                }
+                else
                 {
-                    MultipartFormDataContent form = new MultipartFormDataContent();
-                    var fileInfo = new FileInfo(options.Package);
-                    var content = new StreamContent(fileInfo.OpenRead());
-                    content.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
-                    {
-                        Name = "file",
-                        FileName = fileInfo.Name
-                    };
-                    form.Add(content);
-                    form.Add(new StringContent(ParseCurrentFlag(options.Current)), "isCurrent");
-                    form.Add(new StringContent(options.DotNetVersion), "dotNetVersion");
-                    form.Add(new StringContent("package"), "fileType");
-                    form.Add(GetVersionCompatibility(options.WorksWith), "umbracoVersions");
-                    form.Add(new StringContent(packageInfo.VersionString), "packageVersion");
+                    // Convert the archive option to a regex
+                    var archiveRegex = new Regex("^" + archivePattern.Replace(".", "\\.").Replace("*", "(.*)") + "$", RegexOptions.IgnoreCase);
 
-                    var httpResponse = await client.PostAsync(url, form);
-                    if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
-                    {
-                        packageHelper.WriteError(Resources.Push_ApiKeyInvalid);
-                        Environment.Exit(5); // ERROR_ACCESS_DENIED
-                    }
-                    else if (httpResponse.IsSuccessStatusCode)
-                    {
-                        Console.WriteLine(Resources.Push_Complete, packageFileName);
-                        
-                        // Response is not reported (at the moment)
-                        // var apiReponse = await httpResponse.Content.ReadAsStringAsync();
-                        // Console.WriteLine(apiReponse);
-                    }
+                    // Find packages that match the regex and extract their IDs
+                    var archiveIds = packages.Where(x => archiveRegex.IsMatch(x.Value<string>("Name"))).Select(x => x.Value<int>("Id")).ToArray();
+
+                    packagesToArchive.AddRange(archiveIds);
                 }
             }
-            catch (HttpRequestException ex)
-            {
-                // Could get network error or our.umb down
-                Console.WriteLine(Resources.Error, ex);
-                throw;
-            }
         }
 
-
-        /// <summary>
-        ///  returns the version compatibility string for uploading the package
-        /// </summary>
-        /// <param name="worksWithString"></param>
-        /// <returns></returns>
-        private static StringContent GetVersionCompatibility(string worksWithString)
+        if (packagesToArchive.Count > 0)
         {
-            // TODO: Workout how we can get a latest version from our ? 
-            // TODO: Maybe accept wild cards (8.* -> 8.5.0,8.4.0,8.3.0)
-            // TODO: Work like nuget e.g '> 8.4.0' 
-            var versions = worksWithString
-                                .Split(",", StringSplitOptions.RemoveEmptyEntries)
-                                .Select(x => new UmbracoVersion() { Version = x });
-
-            return new StringContent(JsonConvert.SerializeObject(versions));
-        }
-
-        private static string ParseCurrentFlag(string current)
-        {
-            if (bool.TryParse(current, out bool result))
-            {
-                return result.ToString();
-            }
-
-            return false.ToString();
-        }
-
-        /// <summary>
-        ///  taken from the source of our.umbraco.com
-        /// </summary>
-        private class UmbracoVersion
-        {
-            public string Version { get; set; }
-
-            // We don't need to supply name. but it is in the orginal model.
-            // public string Name { get; set; }
+            await packageHelper.ArchivePackages(keyParts, packagesToArchive.Distinct());
+            Console.WriteLine($"Archived {packagesToArchive.Count} packages matching the archive pattern.");
         }
     }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="packageHelper"></param>
+    /// <param name="packageInfo"></param>
+    /// <returns></returns>
+    private static async Task UploadPackage(PushOptions options, PackageHelper packageHelper, PackageInfo packageInfo)
+    {
+        try
+        {
+            // HttpClient will use this event handler to give us
+            // Reporting on how its progress the file upload
+            var processMsgHandler = new ProgressMessageHandler(new HttpClientHandler());
+            processMsgHandler.HttpSendProgress += (sender, e) =>
+            {
+                    // Could try to reimplement progressbar - but that library did not work in GH Actions :(
+                    var percent = e.ProgressPercentage;
+            };
+
+            var keyParts = packageHelper.SplitKey(options.ApiKey);
+            var packageFileName = Path.GetFileName(options.Package);
+
+            Console.WriteLine(Resources.Push_Uploading, packageFileName);
+
+            var url = "/Umbraco/Api/ProjectUpload/UpdatePackage";
+
+            using (var client = packageHelper.GetClientBase(url, keyParts.Token, keyParts.MemberId, keyParts.ProjectId))
+            {
+                MultipartFormDataContent form = new MultipartFormDataContent();
+                var fileInfo = new FileInfo(options.Package);
+                var content = new StreamContent(fileInfo.OpenRead());
+                content.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+                {
+                    Name = "file",
+                    FileName = fileInfo.Name
+                };
+                form.Add(content);
+                form.Add(new StringContent(ParseCurrentFlag(options.Current)), "isCurrent");
+                form.Add(new StringContent(options.DotNetVersion), "dotNetVersion");
+                form.Add(new StringContent("package"), "fileType");
+                form.Add(GetVersionCompatibility(options.WorksWith), "umbracoVersions");
+                form.Add(new StringContent(packageInfo.VersionString), "packageVersion");
+
+                var httpResponse = await client.PostAsync(url, form);
+                if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    packageHelper.WriteError(Resources.Push_ApiKeyInvalid);
+                    Environment.Exit(5); // ERROR_ACCESS_DENIED
+                }
+                else if (httpResponse.IsSuccessStatusCode)
+                {
+                    Console.WriteLine(Resources.Push_Complete, packageFileName);
+
+                    // Response is not reported (at the moment)
+                    // var apiReponse = await httpResponse.Content.ReadAsStringAsync();
+                    // Console.WriteLine(apiReponse);
+                }
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            // Could get network error or our.umb down
+            Console.WriteLine(Resources.Error, ex);
+            throw;
+        }
+    }
+
+
+    /// <summary>
+    ///  returns the version compatibility string for uploading the package
+    /// </summary>
+    /// <param name="worksWithString"></param>
+    /// <returns></returns>
+    private static StringContent GetVersionCompatibility(string worksWithString)
+    {
+        // TODO: Workout how we can get a latest version from our ? 
+        // TODO: Maybe accept wild cards (8.* -> 8.5.0,8.4.0,8.3.0)
+        // TODO: Work like nuget e.g '> 8.4.0' 
+        var versions = worksWithString
+                            .Split(",", StringSplitOptions.RemoveEmptyEntries)
+                            .Select(x => new UmbracoVersion() { Version = x });
+
+        return new StringContent(JsonConvert.SerializeObject(versions));
+    }
+
+    private static string ParseCurrentFlag(string current)
+    {
+        if (bool.TryParse(current, out bool result))
+        {
+            return result.ToString();
+        }
+
+        return false.ToString();
+    }
+
+    /// <summary>
+    ///  taken from the source of our.umbraco.com
+    /// </summary>
+    private class UmbracoVersion
+    {
+        public string Version { get; set; }
+
+        // We don't need to supply name. but it is in the orginal model.
+        // public string Name { get; set; }
+    }
+}
 }


### PR DESCRIPTION
I was overthinking this - just needs to response to the option value when checking the package exists, then either exit with an appropriate exitCode if required. Because we exit whenever a duplicate exists, there's no issue with archiving or subsequent code.

I've also shifted the archive package logic in PushCommand.Main into a separate method (similar to UploadPackage), to reduce responsibilities in the Main method.

I've tested this with a local run against a draft package - if I attempt to push without the -s flag, umbpack exits with an error, if i push with the -s flag, umbpack exits with the warning message.