### PR TITLE
Add templating to name #41

### DIFF
--- a/src/Verbs/PackCommand.cs
+++ b/src/Verbs/PackCommand.cs
@@ -153,7 +153,7 @@ namespace Umbraco.Packager.CI.Verbs
             if (nameNode != null)
             {
                 var name = nameNode.Value
-                    .Replace(".", "_")
+                    //.Replace(".", "_")
                     .Replace(" ", "_");
 
                 return template.Replace("{name}", name)

--- a/src/Verbs/PackCommand.cs
+++ b/src/Verbs/PackCommand.cs
@@ -108,9 +108,7 @@ namespace Umbraco.Packager.CI.Verbs
             Console.WriteLine(Resources.Pack_GetPackageName);
 
             // work out what we are going to call the package
-            var packageFileName = !string.IsNullOrWhiteSpace(options.PackageFileName)
-                ? options.PackageFileName.EnsureEndsWith(".zip")
-                : GetPackageFileName(packageXml, version);
+            var packageFileName = GetPackageFileName(packageXml, version, options.PackageFileName);
 
             // work out what where we are going to output the package to
             var packageOutputPath = Path.Combine(options.OutputDirectory, packageFileName);
@@ -145,8 +143,12 @@ namespace Umbraco.Packager.CI.Verbs
             return folder;
         }
 
-        private static string GetPackageFileName(XElement packageFile, string version)
+        private static string GetPackageFileName(XElement packageFile, string version, string nameTemplate)
         {
+            var template = !string.IsNullOrWhiteSpace(nameTemplate)
+                ? nameTemplate.EnsureEndsWith(".zip")
+                : "{name}_{version}.zip";
+
             var nameNode = packageFile.Element("info")?.Element("package")?.Element("name");
             if (nameNode != null)
             {
@@ -154,7 +156,8 @@ namespace Umbraco.Packager.CI.Verbs
                     .Replace(".", "_")
                     .Replace(" ", "_");
 
-                return $"{name}_{version}.zip";
+                return template.Replace("{name}", name)
+                    .Replace("{version}", version);
             }
 
             Environment.Exit(2);


### PR DESCRIPTION
lets you template the package name on pack command. 

e.g 
```
umb pack package.xml -v 1.4.3 -n My.Super.Package.{version}.zip
```
will produce My.Super.Package.1.4.3.zip

lets you template:
- `{name}` replaced with the name of the package from the package.xml (as now)
- `{version}` version of the package (either from xml or command line.

the default template if nothing is supplied via the command line is `{name}_{value}.zip`

fixes issue #41 