### PR TITLE
Adding correct metadata to NuGet package

### DIFF
--- a/src/UmbPack.csproj
+++ b/src/UmbPack.csproj
@@ -7,16 +7,20 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>UmbPack</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-
     <AssemblyName>UmbPack</AssemblyName>
     <AssemblyTitle>UmbPack</AssemblyTitle>
-    <Company>The Umbraco Community</Company>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <PackageTags>Umbraco</PackageTags>
-    <Version>0.9.0</Version>
-    <RootNamespace>UmbPack</RootNamespace>     
+    <RootNamespace>UmbPack</RootNamespace>
+
+    <Title>UmbPack</Title>
+    <Description>UmbPack is a CLI tool for building and deploying Umbraco packages</Description>
+    <Authors>The Umbraco Community</Authors>
+    <PackageProjectUrl>https://github.com/umbraco/UmbPack</PackageProjectUrl>
+    <PackageTags>umbraco</PackageTags>
+    <RepositoryUrl>https://github.com/umbraco/UmbPack</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -62,7 +66,5 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  
-  
 
 </Project>


### PR DESCRIPTION
I noticed the [UmbPack NuGet package](https://www.nuget.org/packages/Umbraco.Tools.Packages/) doesn't have a description... 😱

I also included links to the repo so it's easier for people to find how to contribute back.

The `Version` element included previously wasn't needed as this is set by the GitHub Actions build pipeline.