### PR TITLE
Update NuGet package references

### DIFF
--- a/src/UmbPack.csproj
+++ b/src/UmbPack.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -16,20 +15,18 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageTags>Umbraco</PackageTags>
     <Version>0.9.0</Version>
-    <RootNamespace>UmbPack</RootNamespace>     
+    <RootNamespace>UmbPack</RootNamespace>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
     <PackageReference Include="Semver" Version="2.0.6" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Properties\Defaults.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -47,7 +44,6 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="Properties\Defaults.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -62,7 +58,4 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  
-  
-
 </Project>


### PR DESCRIPTION
This updates the following NuGet package references:
- `CommandLineParser` from 2.7.82 to 2.8.0
- `Microsoft.Extensions.DependencyInjection` from 3.1.3 to 3.1.9
- `Microsoft.Extensions.Hosting` from 3.1.3 to 3.1.9
- `Microsoft.Extensions.Http` from 3.1.3 to 3.1.9