### PR TITLE
Don't send default version when pushing

### DIFF
--- a/src/Verbs/PushCommand.cs
+++ b/src/Verbs/PushCommand.cs
@@ -38,7 +38,7 @@ namespace Umbraco.Packager.CI.Verbs
             HelpText = "HelpPushDotNet", ResourceType = typeof(HelpTextResource))]
         public string DotNetVersion { get; set; }
 
-        [Option('w', "WorksWith", Default = "v850", 
+        [Option('w', "WorksWith", 
             HelpText = "HelpPushWorks", ResourceType = typeof(HelpTextResource))]
         public string WorksWith { get; set; }
 
@@ -161,7 +161,10 @@ namespace Umbraco.Packager.CI.Verbs
                     form.Add(new StringContent(ParseCurrentFlag(options.Current)), "isCurrent");
                     form.Add(new StringContent(options.DotNetVersion), "dotNetVersion");
                     form.Add(new StringContent("package"), "fileType");
-                    form.Add(GetVersionCompatibility(options.WorksWith), "umbracoVersions");
+                    if (options.WorksWith != null)
+                    {
+                        form.Add(GetVersionCompatibility(options.WorksWith), "umbracoVersions");
+                    }
                     form.Add(new StringContent(packageInfo.VersionString), "packageVersion");
 
                     var httpResponse = await client.PostAsync(url, form);


### PR DESCRIPTION
This PR removes the default "workswith" value, in combination with [this pr on Our](https://github.com/umbraco/OurUmbraco/pull/666) it will automatically say it works with the latest version unless explicitly specified!

Will close https://github.com/umbraco/UmbPack/issues/42